### PR TITLE
Fix html2jade options for multibyte language user

### DIFF
--- a/lib/html2jade-plus.coffee
+++ b/lib/html2jade-plus.coffee
@@ -1,6 +1,51 @@
 html2jade = require 'html2jade'
 
 module.exports =
+  config:
+    double:
+      title: 'Use double quotes'
+      type: 'boolean'
+      default: false
+      description: 'use double quotes for attributes'
+    nspaces:
+      title: 'Number of spaces'
+      type: 'integer'
+      default: 2
+      description: 'the number of spaces to indent generated
+       files with. Default is 2 spaces'
+    tabs:
+      title: 'Use tabs'
+      type: 'boolean'
+      default: false
+      description: 'use tabs instead of spaces'
+    donotencode:
+      title: 'Do not encode'
+      type: 'boolean'
+      default: false
+      description: 'do not html encode characters.
+       This is useful for template files which may contain
+       expressions like {{username}}'
+    numeric:
+      title: 'Use numeric'
+      type: 'boolean'
+      default: false
+      description: 'use numeric character entities'
+    scalate:
+      title: 'Scalate'
+      type: 'boolean'
+      default: false
+      description: 'generate Scalate(http://scalate.fusesource.org/)
+       variant of jade syntax'
+    noattrcomma:
+      title: 'No attribute commas'
+      type: 'boolean'
+      default: false
+      description: 'omit attribute separating commas'
+    noemptypipe:
+      title: 'No empty pipe'
+      type: 'boolean'
+      default: false
+      description: 'omit lines with only pipe (\'|\') printable character'
 
   activate: (state) ->
 
@@ -20,15 +65,15 @@ module.exports =
     html = "#{html}".replace /\>\s+\</, '><' # HACK: FIXME:
     hasBody = "#{html}".indexOf('<body>') >= 0
     opts =
-      double: true,
-      nspaces: 2,
-      tabs: false,
-      donotencode: true,
+      double: atom.config.get 'html2jade-plus.double'
+      nspaces: atom.config.get 'html2jade-plus.nspaces'
+      tabs: atom.config.get 'html2jade-plus.tabs'
+      donotencode: atom.config.get 'html2jade-plus.donotencode'
       bodyless: not hasBody
-      numeric: false
-      scalate: false
-      noattrcomma: true
-      noemptypipe: true
+      numeric: atom.config.get 'html2jade-plus.numeric'
+      scalate: atom.config.get 'html2jade-plus.scalate'
+      noattrcomma: atom.config.get 'html2jade-plus.noattrcomma'
+      noemptypipe: atom.config.get 'html2jade-plus.noemptypipe'
     html2jade.convertHtml html, opts, (err, jade) ->
       if err
         atom.notifications.addError(err.name or err.toString(), {detail: e.message})

--- a/lib/html2jade-plus.coffee
+++ b/lib/html2jade-plus.coffee
@@ -19,7 +19,17 @@ module.exports =
         editor.getText()
     html = "#{html}".replace /\>\s+\</, '><' # HACK: FIXME:
     hasBody = "#{html}".indexOf('<body>') >= 0
-    html2jade.convertHtml html, { bodyless: not hasBody }, (err, jade) ->
+    opts =
+      double: true,
+      nspaces: 2,
+      tabs: false,
+      donotencode: true,
+      bodyless: not hasBody
+      numeric: false
+      scalate: false
+      noattrcomma: true
+      noemptypipe: true
+    html2jade.convertHtml html, opts, (err, jade) ->
       if err
         atom.notifications.addError(err.name or err.toString(), {detail: e.message})
         return


### PR DESCRIPTION
I adjusted the settings so that I could use it routinely and also to make it a useful tool for a multibyte language user. The resulting output should look something like what you can see at html2jade.org.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/forivall/atom-html2jade-plus/1)

<!-- Reviewable:end -->
